### PR TITLE
Add button_toggle.h/.cpp

### DIFF
--- a/src/main/cpp/button_toggle.cpp
+++ b/src/main/cpp/button_toggle.cpp
@@ -1,0 +1,47 @@
+#include <button_toggle.h>
+
+void ButtonToggle::UpdateToggle(bool button) {
+  if (button) {
+    if (!toggle_pressed) {
+      toggle_on = !toggle_on;
+      toggle_pressed = true;
+    }
+  } else {
+    toggle_pressed = false;
+  }
+}
+
+bool ButtonToggle::GetToggleNoDebounce(bool button) {
+  UpdateToggle(button);
+
+  if (toggle_on) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool ButtonToggle::GetToggle(bool button) {
+  UpdateToggle(Debounce(button));
+
+  if (toggle_on) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void ButtonToggle::SetDebouncePeriod(float period) {
+  debounce_period = units::second_t(period);
+}
+
+bool ButtonToggle::Debounce(bool button) {
+  units::second_t now = frc::Timer::GetFPGATimestamp();
+  if (button) {
+    if ((now - latest) > debounce_period) {
+      latest = now;
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/main/include/button_toggle.h
+++ b/src/main/include/button_toggle.h
@@ -1,0 +1,30 @@
+#ifndef BUTTONTOGGLE
+#define BUTTONTOGGLE
+
+#include <iostream>
+#include <frc/Timer.h>
+
+class ButtonToggle {
+public:
+  ButtonToggle() {
+    debounce_period = units::second_t(.1);
+  }
+  ButtonToggle(float period) {
+    debounce_period = units::second_t(period);
+  }
+
+  bool GetToggleNoDebounce(bool button);
+  void SetDebouncePeriod(float period);
+  bool GetToggle(bool button);
+
+private:
+  void UpdateToggle(bool button);
+  bool Debounce(bool button);
+
+  bool toggle_pressed = 0;
+  bool toggle_on = 0;
+
+  units::second_t latest = units::second_t(0);
+  units::second_t debounce_period;
+};
+#endif


### PR DESCRIPTION
This class makes button toggle easy. Has optional debouncer!
Basically, pass a `GetRawButton` into `GetToggle()` or `GetToggleNoDebounce()` and then it will return a bool that signifies the toggle state.

Note: tried to do this with function pointers (kinda like JS callbacks), apparently that's not cool in cpp